### PR TITLE
Remove a comma in the README's sample configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,6 @@ The config file contains your Transifex project info for accessing the [Transife
     */
     translationMode: "reviewed",
   },
-
-  },
   /*
      Settings for your local project 
   */


### PR DESCRIPTION
Hi,

This is not a real fix for the underlying issue (see below) but this should prevent other people that will copy/paste blindly the sample configuration to fall into the `could not find config file for transifex-resjson` issue.

Underlying issue: This superfluous comma make the JSON parsing fail (actual error is `Unexpected token: ',', expected end-of-input`) but since the `catch` doesn't check the error itself and simply display `could not find config file for transifex-resjson`, it's not clear that this is actually a JSON parsing issue... I had to hack the plugin's code to understand what was the real issue.

Cheers!

Edit: I also removed a superfluous `},` that's triggering a parsing issue too. ;)
