### PR TITLE
Allow more language codes

### DIFF
--- a/tasks/transifex-resjson-tasks.js
+++ b/tasks/transifex-resjson-tasks.js
@@ -720,7 +720,7 @@ module.exports = function (grunt) {
         undefined if the code isn't of correct format.
     */
     function mapToTxLangCode(str) {
-        var matcher = str.match(/([a-z]{2})-([A-Z]{2}|latn)$/i);
+        var matcher = str.match(/([a-z]{2,3})(?:[-_]([a-z]{2}|latn))?$/i);
         if (matcher && matcher.length === 3) {
             if (_.isString(matcher[2]) && matcher[2].toLowerCase() === "latn") {
                 return matcher[1] + "@latin";

--- a/tasks/transifex-resjson-tasks.js
+++ b/tasks/transifex-resjson-tasks.js
@@ -720,7 +720,7 @@ module.exports = function (grunt) {
         undefined if the code isn't of correct format.
     */
     function mapToTxLangCode(str) {
-        var matcher = str.match(/([a-z]{2,3})(?:[-_]([a-z]{2}|latn))?$/i);
+        var matcher = str.match(/([a-z]{2,3})(?:-([a-z]{2}|latn))?$/i);
         if (matcher && matcher.length === 3) {
             if (_.isString(matcher[2]) && matcher[2].toLowerCase() === "latn") {
                 return matcher[1] + "@latin";


### PR DESCRIPTION
Related to #12.

Per Transifex documentation (https://www.transifex.com/languages/), language
codes in the form `en` (2 chars) / `ach` (3 chars) and `en_US` ("_" separator)
are allowed, so let's allow them here too!

I hope that's an acceptable change?

Cheers!
